### PR TITLE
Configure renovate to update @typescript-eslint/parser

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,16 @@
       ],
       "automerge": true,
       "automergeStrategy": "merge-commit"
+    },
+    {
+      "packageNames": [
+        "@typescript-eslint/parser"
+      ],
+      "upgradeTypes": [
+        "minor"
+      ],
+      "automerge": true,
+      "automergeStrategy": "merge-commit"
     }
   ]
 }


### PR DESCRIPTION
Add packageRules object to open and automatically merge minor version upgrades for `@typescript-eslint/parser`.

Although the package does use semver ([see documentation](https://main--typescript-eslint.netlify.app/users/versioning/)), I chose to update automatically because:
- Minor updates to this package have never failed a CI check or caused an incident on this project
- As a dev tool for linting, I would expect to see a CI check fail if a breaking change were introduced