### PR TITLE
Detect local timezone from published dates

### DIFF
--- a/utils/generateRssFeed.ts
+++ b/utils/generateRssFeed.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import RSS from "rss";
 
 import { getAllPostsManually } from "./getAllPostsManually";
+import { parseUKDate } from "./parseUkDate";
 
 const SITE_URL = "https://bbn.digital/";
 
@@ -14,22 +15,25 @@ export default async function generateRssFeed() {
     site_url: SITE_URL,
     feed_url: `${SITE_URL}rss.xml`,
     image_url: `${SITE_URL}img/apple-touch-icon.png`,
-    pubDate: new Date(),
+    pubDate: new Date().toLocaleString("en-GB", { timeZone: "Europe/London" }),
     copyright: `All rights reserved ${new Date().getFullYear()}, Aaron Cawte`,
   };
 
   const feed = new RSS(feedOptions);
 
   const allPosts = getAllPostsManually({ indexable: true });
-
   allPosts
     .filter((post) => !!post.publishedAt)
     .map((post) => {
+      const publishedDate =
+        typeof post.publishedAt === "string"
+          ? parseUKDate(post.publishedAt)
+          : "";
       feed.item({
         title: post.title,
         description: post.description,
         url: `${SITE_URL}posts/${post.slug}`,
-        date: post.publishedAt as string,
+        date: publishedDate,
       });
     });
 

--- a/utils/parseUkDate.ts
+++ b/utils/parseUkDate.ts
@@ -1,0 +1,16 @@
+export const parseUKDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const formatter = new Intl.DateTimeFormat("en-GB", {
+    timeZone: "Europe/London",
+    timeZoneName: "long",
+  });
+
+  const parts = formatter.formatToParts(date);
+  const timeZonePart = parts.find((p) => p.type === "timeZoneName");
+
+  if (timeZonePart && timeZonePart.value.includes("Summer")) {
+    date.setHours(date.getHours() - 1);
+  }
+
+  return date;
+};


### PR DESCRIPTION
## What
Determine the local UK timezone at the time of a post's publication, and adjust the time to GMT/UTC for the RSS feed.

## Why
Previously, dates given in BST were parsed as GMT, causing them to appear one hour later than intended.